### PR TITLE
Eq and Show instances for VNode and its descendants

### DIFF
--- a/src/Freedom/UI.purs
+++ b/src/Freedom/UI.purs
@@ -98,6 +98,39 @@ data VElement state
 -- | The type of virtual node.
 data VNode state = VNode String (VElement state)
 
+instance eqVNode :: Eq (VNode state) where
+  eq (VNode str el) (VNode str2 el2) = str == str2 && el == el2
+
+instance eqVElement :: Eq (VElement state) where
+  eq (Text str1) (Text str2) = str1 == str2
+  eq (Text _) _ = false
+  eq _ (Text _) = false
+  eq (Element b1 vobj1) (Element b2 vobj2) = b1 == b2 && (equalVObject vobj1 vobj2)
+
+equalVObject :: forall state. VObject state -> VObject state -> Boolean
+equalVObject vObj1 vObj2 = 
+    vObj1.tagName == vObj2.tagName 
+    && vObj1.fingerprint == vObj2.fingerprint
+    && vObj1.props == vObj2.props
+    && vObj1.children == vObj2.children
+
+instance showVNode :: Show (VNode state) where
+  show (VNode str el) = "Vnode: " <> str <> " " <> show el
+
+instance showVElement :: Show (VElement state) where
+  show (Text str) = "Text: " <> str
+  show (Element b vObj) = "Element (isManual: " 
+      <> show b 
+      <> "; " 
+      <> showVObject vObj <> ")" 
+
+showVObject :: forall s. VObject s -> String
+showVObject obj = "VObject (tagName: " <> obj.tagName
+    <> "; fingerprint: " <> obj.fingerprint
+    <> "; props: " <> show obj.props
+    <> "; children: " <> show obj.children <> ")"
+
+
 instance hasKeyVNode :: HasKey (VNode state) where
   getKey idx (VNode k velement) =
     case velement of

--- a/src/Freedom/UI.purs
+++ b/src/Freedom/UI.purs
@@ -103,9 +103,8 @@ instance eqVNode :: Eq (VNode state) where
 
 instance eqVElement :: Eq (VElement state) where
   eq (Text str1) (Text str2) = str1 == str2
-  eq (Text _) _ = false
-  eq _ (Text _) = false
   eq (Element b1 vobj1) (Element b2 vobj2) = b1 == b2 && (equalVObject vobj1 vobj2)
+  eq _ _ = false
 
 equalVObject :: forall state. VObject state -> VObject state -> Boolean
 equalVObject vObj1 vObj2 = 

--- a/src/Freedom/UI.purs
+++ b/src/Freedom/UI.purs
@@ -114,20 +114,14 @@ equalVObject vObj1 vObj2 =
     && vObj1.children == vObj2.children
 
 instance showVNode :: Show (VNode state) where
-  show (VNode str el) = "Vnode: " <> str <> " " <> show el
+  show (VNode k el) = "(VNode " <> show k <> " " <> show el <> ")"
 
 instance showVElement :: Show (VElement state) where
-  show (Text str) = "Text: " <> str
-  show (Element b vObj) = "Element (isManual: " 
-      <> show b 
-      <> "; " 
-      <> showVObject vObj <> ")" 
+  show (Text str) = "(Text: " <> str <> ")"
+  show (Element isManual vObj) = "(Element " <> show isManual <> " " <> showVObject vObj <> ")"
 
 showVObject :: forall s. VObject s -> String
-showVObject obj = "VObject (tagName: " <> obj.tagName
-    <> "; fingerprint: " <> obj.fingerprint
-    <> "; props: " <> show obj.props
-    <> "; children: " <> show obj.children <> ")"
+showVObject obj = "{ tagName: " <> show obj.tagName <> ", fingerprint: " <> show obj.fingerprint <> ", props: " <> show obj.props <> ", children: " <> show obj.children <> "}"
 
 
 instance hasKeyVNode :: HasKey (VNode state) where

--- a/src/Freedom/UI.purs
+++ b/src/Freedom/UI.purs
@@ -117,7 +117,7 @@ instance showVNode :: Show (VNode state) where
   show (VNode k el) = "(VNode " <> show k <> " " <> show el <> ")"
 
 instance showVElement :: Show (VElement state) where
-  show (Text str) = "(Text: " <> str <> ")"
+  show (Text str) = "(Text " <> str <> ")"
   show (Element isManual vObj) = "(Element " <> show isManual <> " " <> showVObject vObj <> ")"
 
 showVObject :: forall s. VObject s -> String

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,10 +6,13 @@ import Effect (Effect)
 import Test.UI.Diff (testDiff)
 import Test.UI.Eq (testVNodeEq)
 import Test.UI.Show (testVNodeShow)
+import Test.UI.Example (testView)
 import Test.Unit.Main (runTest)
+
 
 main :: Effect Unit
 main = runTest do
   testDiff
   testVNodeEq
   testVNodeShow
+  testView

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,8 +4,12 @@ import Prelude
 
 import Effect (Effect)
 import Test.UI.Diff (testDiff)
+import Test.UI.Eq (testVNodeEq)
+import Test.UI.Show (testVNodeShow)
 import Test.Unit.Main (runTest)
 
 main :: Effect Unit
 main = runTest do
   testDiff
+  testVNodeEq
+  testVNodeShow

--- a/test/UI/Eq.purs
+++ b/test/UI/Eq.purs
@@ -13,6 +13,10 @@ testVNodeEq = suite "Equalitiy of elements" do
   test "single element equal" do
      Assert.assert "should equal" (H.div == H.div)
      Assert.assert "should not equal" (H.h1 /= H.div)
+  test "text equal" do
+     Assert.assert "should not equal tag" (H.t "T" /= H.div)
+     Assert.assert "should not equal different text" (H.t "T" /= H.t "D")
+     Assert.assert "should equal same text" (H.t "T" == H.t "T")
   test "rendering manually" do
     Assert.assert "should not equal" (renderingManually H.div /= H.div)
   test "fingerprint" do

--- a/test/UI/Eq.purs
+++ b/test/UI/Eq.purs
@@ -1,0 +1,41 @@
+module Test.UI.Eq where
+
+
+import Prelude (discard, (/=), (==),(#))
+import Freedom.Markup as H
+import Freedom.UI (VNode, fingerprint, renderingManually)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert as Assert
+
+
+testVNodeEq :: TestSuite
+testVNodeEq = suite "Equalitiy of elements" do
+  test "single element equal" do
+     Assert.assert "should equal" (H.div == H.div)
+     Assert.assert "should not equal" (H.h1 /= H.div)
+  test "rendering manually" do
+    Assert.assert "should not equal" (renderingManually H.div /= H.div)
+  test "fingerprint" do
+    Assert.assert "should not equal" (fingerprint "fp" H.div /= H.div)
+  test "no props" do
+    Assert.assert "should not equal" ((H.div # H.title "test" :: forall s. VNode s) /= H.div)
+  test "same props different value" do
+    Assert.assert "should not equal" (
+        (H.div # H.title "test" :: forall s. VNode s) 
+        /= (H.div # H.title "other" :: forall s. VNode s))
+  test "same props same value" do
+    Assert.assert "should equal" (
+        (H.div # H.title "test" :: forall s. VNode s) 
+        == (H.div # H.title "test" :: forall s. VNode s))
+  test "more props" do
+    Assert.assert "should not equal" (
+        (H.div # H.title "test" # H.id "id" :: forall s. VNode s) 
+        /= (H.div # H.title "test" :: forall s. VNode s))
+  test "children" do
+    Assert.assert "should not equal" (
+        (H.div # H.kids [H.div] :: forall s. VNode s) 
+        /= (H.div # H.kids [H.h1] :: forall s. VNode s))
+    
+     
+
+

--- a/test/UI/ExampleUnitTest.purs
+++ b/test/UI/ExampleUnitTest.purs
@@ -1,0 +1,49 @@
+module Test.UI.Example where
+
+import Prelude ((#), Unit, (-), (+), const, ($), show)
+
+import Effect (Effect)
+import Test.Unit.Assert as Assert
+import Test.Unit (TestSuite, suite, test)
+import Freedom.UI (VNode, Operation)
+import Freedom.Markup as H
+
+
+type State = Int
+
+
+testView :: TestSuite
+testView = suite "Example for Testing rendering function in unit test" do
+  test "test view with state 1" do
+    Assert.equal expected $ view 1
+        where 
+            expected = H.div # H.kids
+                [ 
+                    H.button # H.kids [ H.t "-" ]
+                    , H.div # H.kids [ H.t "1"]
+                    , H.button # H.kids [ H.t "+" ]
+                ]
+
+
+-- view function from the counter example
+view :: State -> VNode State
+view count =
+  H.div # H.kids
+    [ H.button
+        # H.onClick (const decrement)
+        # H.kids [ H.t "-" ]
+    , H.div
+        # H.kids [ H.t $ show count ]
+    , H.button
+        # H.onClick (const increment)
+        # H.kids [ H.t "+" ]
+    ]
+
+
+increment :: Operation State -> Effect Unit
+increment operation =
+  operation.query.reduce (_ + 1)
+
+decrement :: Operation State -> Effect Unit
+decrement operation =
+  operation.query.reduce (_ - 1)

--- a/test/UI/Show.purs
+++ b/test/UI/Show.purs
@@ -1,0 +1,29 @@
+module Test.UI.Show where
+
+
+import Prelude (discard, show, ($), (<>))
+import Freedom.Markup as H
+import Freedom.UI (fingerprint, renderingManually)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert as Assert
+
+
+testVNodeShow :: TestSuite
+testVNodeShow = suite "Showing dom elements" do
+  test "single element" do
+     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
+        <> "props: (fromFoldable []); children: []))") (show H.div)
+  test "is manual" do
+     Assert.equal ("Vnode:  Element (isManual: true; VObject (tagName: div; fingerprint: ; "
+     <> "props: (fromFoldable []); children: []))") (show $ renderingManually H.div)
+  test "fingerprint" do
+     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: fp; "
+     <> "props: (fromFoldable []); children: []))") (show $ fingerprint "fp" H.div)
+  test "props" do
+     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
+     <> "props: (fromFoldable [(Tuple \"id\" \"id\")]); children: []))") (show $ H.id "id" H.div)
+  test "kids" do
+     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
+     <> "props: (fromFoldable []); children: [Vnode:  Element (isManual: false; "
+     <> "VObject (tagName: div; fingerprint: ; props: (fromFoldable []); children: []))]))") 
+         (show $ H.kids [H.div] H.div)

--- a/test/UI/Show.purs
+++ b/test/UI/Show.purs
@@ -11,19 +11,19 @@ import Test.Unit.Assert as Assert
 testVNodeShow :: TestSuite
 testVNodeShow = suite "Showing dom elements" do
   test "single element" do
-     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
-        <> "props: (fromFoldable []); children: []))") (show H.div)
+     Assert.equal ("(VNode \"\" (Element false { tagName: \"div\", fingerprint: \"\", "
+        <> "props: (fromFoldable []), children: []}))") (show H.div)
   test "is manual" do
-     Assert.equal ("Vnode:  Element (isManual: true; VObject (tagName: div; fingerprint: ; "
-     <> "props: (fromFoldable []); children: []))") (show $ renderingManually H.div)
+     Assert.equal ("(VNode \"\" (Element true { tagName: \"div\", fingerprint: \"\", "
+     <> "props: (fromFoldable []), children: []}))") (show $ renderingManually H.div)
   test "fingerprint" do
-     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: fp; "
-     <> "props: (fromFoldable []); children: []))") (show $ fingerprint "fp" H.div)
+     Assert.equal ("(VNode \"\" (Element false { tagName: \"div\", fingerprint: \"fp\", "
+     <> "props: (fromFoldable []), children: []}))") (show $ fingerprint "fp" H.div)
   test "props" do
-     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
-     <> "props: (fromFoldable [(Tuple \"id\" \"id\")]); children: []))") (show $ H.id "id" H.div)
+     Assert.equal ("(VNode \"\" (Element false { tagName: \"div\", fingerprint: \"\", "
+     <> "props: (fromFoldable [(Tuple \"id\" \"id\")]), children: []}))") (show $ H.id "id" H.div)
   test "kids" do
-     Assert.equal ("Vnode:  Element (isManual: false; VObject (tagName: div; fingerprint: ; "
-     <> "props: (fromFoldable []); children: [Vnode:  Element (isManual: false; "
-     <> "VObject (tagName: div; fingerprint: ; props: (fromFoldable []); children: []))]))") 
+     Assert.equal ("(VNode \"\" (Element false { tagName: \"div\", fingerprint: \"\", "
+     <> "props: (fromFoldable []), children: [(VNode \"\" (Element false "
+     <> "{ tagName: \"div\", fingerprint: \"\", props: (fromFoldable []), children: []}))]}))") 
          (show $ H.kids [H.div] H.div)


### PR DESCRIPTION
This makes unit tests for view functions like this possible:

```purescript
-- view
view count = H.div # H.kids [ H.t $ show count ]

-- test
  test "test view with state 1" do
    Assert.equal (H.div # H.kids [ H.t "1"]) (view 1)
```